### PR TITLE
The id is now reflected to the containing collection when it changes in ...

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -4,6 +4,7 @@ import {
 from "./EventEmitter";
 
 export class Model extends EventEmitter {
+  
   constructor(obj = {}) {
     this.arguments = new Map();
 
@@ -20,6 +21,8 @@ export class Model extends EventEmitter {
     this.set(obj, {
       "silent": true
     });
+    
+    this._type = "Model";
     super();
   }
 
@@ -35,19 +38,21 @@ export class Model extends EventEmitter {
     "silent": false
   }) {
     let hasChanged = false;
+    let oldValues = {};
     for (let key in values) {
       let newValue = values[key],
         oldValue = this.arguments.get(key);
       if (newValue !== oldValue && values.hasOwnProperty(key)) {
+        oldValues[key] = newValue;
         this.arguments.set(key, newValue);
         if (!options.silent) {
-          this.trigger(`change:${key}`, this);
+          this.trigger(`change:${key}`, this, oldValue);
         }
         hasChanged = true;
       }
     }
     if (!options.silent && hasChanged) {
-      this.trigger("change", this);
+      this.trigger("change", this, oldValues);
     }
   }
 

--- a/test/Collection.js
+++ b/test/Collection.js
@@ -2,6 +2,7 @@
   "use strict";
   var should = require("should");
   var Collection = require("..").Collection;
+  var Model = require("..").Model;
   var _ = require("underscore");
 
   describe("Collection", function() {
@@ -16,6 +17,21 @@
         }]);
         col.length.should.equal(2);
       });
+      
+      it("should reflect model id changes to the collection keys", function() {
+        let m = new Model({
+          "id": "one",
+          "name": "micky"
+        });
+        let col = new Collection();
+        col.add(m);
+        col.get("one").get("name").should.equal("micky");
+        col.get("one").set({
+          "id": "two"
+        });
+        col.get("two").get("name").should.equal("micky");
+      });
+      
     });
 
     describe("initialize", function() {
@@ -50,6 +66,16 @@
         collection.length.should.equal(2);
         collection.get(1).get("hello").should.equal("world");
         collection.get(2).get("hello").should.equal("something");
+      });
+      
+      it("should add models as models to the collection", function() {
+        let m = new Model({
+          "id": "hello",
+          "name": "model"
+        });
+        let col = new Collection();
+        col.add(m);
+        col.get("hello").get("name").should.equal("model");
       });
 
       it("should trigger an add event with the added objects", function(done) {


### PR DESCRIPTION
...the model

Tests were also written and to help testing some variables to the models and collections were added. e.g. the _type makes it easier to determine if the passed in values are models or not when adding to collection

FIXES this issue https://github.com/ksnabb/flux-stores/issues/17
